### PR TITLE
feat: add Evaluations resource with read-only evaluation API support

### DIFF
--- a/src/client/evaluations.ts
+++ b/src/client/evaluations.ts
@@ -1,0 +1,214 @@
+/**
+ * VLM Run API Evaluations resource.
+ */
+
+import { Client, APIRequestor } from "./base_requestor";
+import {
+  EvaluationRunResponse,
+  EvaluationRunListResponse,
+  EvaluationPreviewResponse,
+  EvaluationMetricsResponse,
+  EvaluationSummaryStatsResponse,
+  EvaluationUniqueSourcesResponse,
+  RunEvaluationRequest,
+  OptimizeSkillRequest,
+  OptimizeSkillResponse,
+  RerunSkillRequest,
+  RerunSkillResponse,
+  EvaluationSourceType,
+} from "./types";
+
+export class Evaluations {
+  private client: Client;
+  private requestor: APIRequestor;
+
+  constructor(client: Client) {
+    this.client = client;
+    this.requestor = new APIRequestor(client);
+  }
+
+  /**
+   * List evaluation runs with pagination and filtering.
+   *
+   * @param options - Query options for listing evaluation runs
+   * @returns Paginated list of evaluation runs
+   */
+  async list(options?: {
+    limit?: number;
+    offset?: number;
+    orderBy?: string;
+    descending?: boolean;
+    createdAtGte?: string;
+    createdAtLte?: string;
+  }): Promise<EvaluationRunListResponse> {
+    const params: Record<string, any> = {
+      limit: options?.limit ?? 30,
+      offset: options?.offset ?? 0,
+      order_by: options?.orderBy ?? "created_at",
+      descending: options?.descending ?? true,
+    };
+    if (options?.createdAtGte) params.created_at__gte = options.createdAtGte;
+    if (options?.createdAtLte) params.created_at__lte = options.createdAtLte;
+
+    const [response] =
+      await this.requestor.request<EvaluationRunListResponse>(
+        "GET",
+        "evaluations",
+        params
+      );
+    return response;
+  }
+
+  /**
+   * Get a specific evaluation run by ID.
+   *
+   * @param runId - The evaluation run ID
+   * @returns The evaluation run details
+   */
+  async get(runId: string): Promise<EvaluationRunResponse> {
+    const [response] = await this.requestor.request<EvaluationRunResponse>(
+      "GET",
+      `evaluations/${runId}`
+    );
+    return response;
+  }
+
+  /**
+   * Trigger a new evaluation run.
+   *
+   * @param body - The evaluation run request body
+   * @returns The created evaluation run
+   */
+  async run(body: RunEvaluationRequest): Promise<EvaluationRunResponse> {
+    const [response] = await this.requestor.request<EvaluationRunResponse>(
+      "POST",
+      "evaluations/run",
+      undefined,
+      body
+    );
+    return response;
+  }
+
+  /**
+   * Get a preview of available data for an evaluation source.
+   *
+   * @param options - Preview query parameters
+   * @returns Preview of available evaluation data
+   */
+  async preview(options: {
+    sourceType: EvaluationSourceType;
+    sourceId: string;
+    dataFrom?: string;
+    dataTo?: string;
+  }): Promise<EvaluationPreviewResponse> {
+    const params: Record<string, string> = {
+      source_type: options.sourceType,
+      source_id: options.sourceId,
+    };
+    if (options.dataFrom) params.data_from = options.dataFrom;
+    if (options.dataTo) params.data_to = options.dataTo;
+
+    const [response] =
+      await this.requestor.request<EvaluationPreviewResponse>(
+        "GET",
+        "evaluations/preview",
+        params
+      );
+    return response;
+  }
+
+  /**
+   * Get aggregated metrics across evaluation runs.
+   *
+   * @param options - Metrics query parameters
+   * @returns Aggregated evaluation metrics
+   */
+  async metrics(options?: {
+    limit?: number;
+    sourceType?: string;
+    sourceLabel?: string;
+  }): Promise<EvaluationMetricsResponse> {
+    const params: Record<string, any> = { limit: options?.limit ?? 20 };
+    if (options?.sourceType) params.source_type = options.sourceType;
+    if (options?.sourceLabel) params.source_label = options.sourceLabel;
+
+    const [response] =
+      await this.requestor.request<EvaluationMetricsResponse>(
+        "GET",
+        "evaluations/metrics",
+        params
+      );
+    return response;
+  }
+
+  /**
+   * Get summary statistics for evaluation runs.
+   *
+   * @returns Summary stats including total runs and source type counts
+   */
+  async summaryStats(): Promise<EvaluationSummaryStatsResponse> {
+    const [response] =
+      await this.requestor.request<EvaluationSummaryStatsResponse>(
+        "GET",
+        "evaluations/summary-stats"
+      );
+    return response;
+  }
+
+  /**
+   * Get unique evaluation sources for filtering.
+   *
+   * @returns Unique (type, label) pairs
+   */
+  async uniqueSources(): Promise<EvaluationUniqueSourcesResponse> {
+    const [response] =
+      await this.requestor.request<EvaluationUniqueSourcesResponse>(
+        "GET",
+        "evaluations/unique-sources"
+      );
+    return response;
+  }
+
+  /**
+   * Delete an evaluation run.
+   *
+   * @param runId - The evaluation run ID to delete
+   */
+  async delete(runId: string): Promise<void> {
+    await this.requestor.request("DELETE", `evaluations/${runId}`);
+  }
+
+  /**
+   * Optimize a skill based on evaluation data.
+   *
+   * @param body - The optimization request body
+   * @returns The optimization result
+   */
+  async optimizeSkill(
+    body: OptimizeSkillRequest
+  ): Promise<OptimizeSkillResponse> {
+    const [response] = await this.requestor.request<OptimizeSkillResponse>(
+      "POST",
+      "evaluations/optimize",
+      undefined,
+      body
+    );
+    return response;
+  }
+
+  /**
+   * Re-run an evaluation with different parameters.
+   *
+   * @param body - The rerun request body
+   * @returns The rerun result
+   */
+  async rerunSkill(body: RerunSkillRequest): Promise<RerunSkillResponse> {
+    const [response] = await this.requestor.request<RerunSkillResponse>(
+      "POST",
+      "evaluations/rerun",
+      undefined,
+      body
+    );
+    return response;
+  }
+}

--- a/src/client/evaluations.ts
+++ b/src/client/evaluations.ts
@@ -10,7 +10,9 @@ import {
   EvaluationMetricsResponse,
   EvaluationSummaryStatsResponse,
   EvaluationUniqueSourcesResponse,
-  EvaluationSourceType,
+  EvaluationListOptions,
+  EvaluationPreviewOptions,
+  EvaluationMetricsOptions,
 } from "./types";
 
 export class Evaluations {
@@ -28,14 +30,7 @@ export class Evaluations {
    * @param options - Query options for listing evaluation runs
    * @returns Paginated list of evaluation runs
    */
-  async list(options?: {
-    limit?: number;
-    offset?: number;
-    orderBy?: string;
-    descending?: boolean;
-    createdAtGte?: string;
-    createdAtLte?: string;
-  }): Promise<EvaluationRunListResponse> {
+  async list(options?: EvaluationListOptions): Promise<EvaluationRunListResponse> {
     const params: Record<string, any> = {
       limit: options?.limit ?? 30,
       offset: options?.offset ?? 0,
@@ -74,12 +69,7 @@ export class Evaluations {
    * @param options - Preview query parameters
    * @returns Preview of available evaluation data
    */
-  async preview(options: {
-    sourceType: EvaluationSourceType;
-    sourceId: string;
-    dataFrom?: string;
-    dataTo?: string;
-  }): Promise<EvaluationPreviewResponse> {
+  async preview(options: EvaluationPreviewOptions): Promise<EvaluationPreviewResponse> {
     const params: Record<string, string> = {
       source_type: options.sourceType,
       source_id: options.sourceId,
@@ -102,11 +92,7 @@ export class Evaluations {
    * @param options - Metrics query parameters
    * @returns Aggregated evaluation metrics
    */
-  async metrics(options?: {
-    limit?: number;
-    sourceType?: string;
-    sourceLabel?: string;
-  }): Promise<EvaluationMetricsResponse> {
+  async metrics(options?: EvaluationMetricsOptions): Promise<EvaluationMetricsResponse> {
     const params: Record<string, any> = { limit: options?.limit ?? 20 };
     if (options?.sourceType) params.source_type = options.sourceType;
     if (options?.sourceLabel) params.source_label = options.sourceLabel;

--- a/src/client/evaluations.ts
+++ b/src/client/evaluations.ts
@@ -10,11 +10,6 @@ import {
   EvaluationMetricsResponse,
   EvaluationSummaryStatsResponse,
   EvaluationUniqueSourcesResponse,
-  RunEvaluationRequest,
-  OptimizeSkillRequest,
-  OptimizeSkillResponse,
-  RerunSkillRequest,
-  RerunSkillResponse,
   EvaluationSourceType,
 } from "./types";
 
@@ -69,22 +64,6 @@ export class Evaluations {
     const [response] = await this.requestor.request<EvaluationRunResponse>(
       "GET",
       `evaluations/${runId}`
-    );
-    return response;
-  }
-
-  /**
-   * Trigger a new evaluation run.
-   *
-   * @param body - The evaluation run request body
-   * @returns The created evaluation run
-   */
-  async run(body: RunEvaluationRequest): Promise<EvaluationRunResponse> {
-    const [response] = await this.requestor.request<EvaluationRunResponse>(
-      "POST",
-      "evaluations/run",
-      undefined,
-      body
     );
     return response;
   }
@@ -178,37 +157,4 @@ export class Evaluations {
     await this.requestor.request("DELETE", `evaluations/${runId}`);
   }
 
-  /**
-   * Optimize a skill based on evaluation data.
-   *
-   * @param body - The optimization request body
-   * @returns The optimization result
-   */
-  async optimizeSkill(
-    body: OptimizeSkillRequest
-  ): Promise<OptimizeSkillResponse> {
-    const [response] = await this.requestor.request<OptimizeSkillResponse>(
-      "POST",
-      "evaluations/optimize",
-      undefined,
-      body
-    );
-    return response;
-  }
-
-  /**
-   * Re-run an evaluation with different parameters.
-   *
-   * @param body - The rerun request body
-   * @returns The rerun result
-   */
-  async rerunSkill(body: RerunSkillRequest): Promise<RerunSkillResponse> {
-    const [response] = await this.requestor.request<RerunSkillResponse>(
-      "POST",
-      "evaluations/rerun",
-      undefined,
-      body
-    );
-    return response;
-  }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -704,3 +704,147 @@ export interface AgentSkill {
   version?: string;
   type?: string;
 }
+
+// --- Evaluation types ---
+
+export type EvaluationSourceType = "agent" | "request_domain" | "skill";
+export type EvaluatorType =
+  | "field_accuracy"
+  | "fuzzy_field_match"
+  | "llm_judge"
+  | "equals_expected";
+
+export interface RunEvaluationRequest {
+  source_type: EvaluationSourceType;
+  source_id: string;
+  source_label: string;
+  execution_ids?: string[] | null;
+  request_ids?: string[] | null;
+  skill_ids?: string[] | null;
+  data_from?: string | null;
+  data_to?: string | null;
+  evaluators?: EvaluatorType[] | null;
+  infer_corrections?: boolean | null;
+}
+
+export interface EvaluationRunResponse {
+  id: string;
+  source_type: EvaluationSourceType;
+  source_id: string | null;
+  source_label: string;
+  source_version: string | null;
+  status: string;
+  accuracy: number | null;
+  api_completion_rate: number | null;
+  total_items: number | null;
+  total_with_feedback: number | null;
+  data_from: string | null;
+  data_to: string | null;
+  results: Record<string, any>;
+  created_at: string | null;
+}
+
+export interface EvaluationRunListResponse {
+  data: EvaluationRunResponse[];
+  count: number;
+}
+
+export interface EvaluationPreviewResponse {
+  total_items: number;
+  total_with_feedback: number;
+  feedback_with_corrections: number;
+  latest_item_at: string | null;
+}
+
+export interface AccuracyTrendPoint {
+  run_id: string;
+  accuracy: number;
+  api_completion_rate: number | null;
+  fuzzy_match_rate: number | null;
+  exact_match_rate: number | null;
+  source_type: string | null;
+  source_label: string | null;
+  created_at: string;
+}
+
+export interface FieldAccuracyAggregate {
+  field: string;
+  avg_accuracy: number;
+  total_correct: number;
+  total_count: number;
+}
+
+export interface LatencyTrendPoint {
+  run_id: string;
+  created_at: string;
+  p50_ms: number | null;
+  p90_ms: number | null;
+  p95_ms: number | null;
+}
+
+export interface EvaluationMetricsResponse {
+  accuracy_trend: AccuracyTrendPoint[];
+  avg_accuracy: number | null;
+  accuracy_delta: number | null;
+  avg_api_completion_rate: number | null;
+  avg_fuzzy_match_rate: number | null;
+  avg_exact_match_rate: number | null;
+  field_accuracies: FieldAccuracyAggregate[];
+  latency_trend: LatencyTrendPoint[];
+  p50_ms: number | null;
+  p90_ms: number | null;
+  p95_ms: number | null;
+}
+
+export interface SourceTypeCount {
+  type: string;
+  label: string;
+  count: number;
+}
+
+export interface EvaluationSummaryStatsResponse {
+  total_runs: number;
+  source_type_counts: SourceTypeCount[];
+}
+
+export interface UniqueSource {
+  type: string;
+  label: string;
+}
+
+export interface EvaluationUniqueSourcesResponse {
+  sources: UniqueSource[];
+}
+
+export interface OptimizeSkillRequest {
+  skill_id: string;
+  skill_ids?: string[] | null;
+  data_from?: string | null;
+  data_to?: string | null;
+  infer_corrections?: boolean;
+  n_samples?: number;
+}
+
+export interface OptimizeSkillResponse {
+  skill_id: string;
+  name: string;
+  version: string;
+  original_skill_id: string;
+  total_pairs: number;
+  sampled_pairs: number;
+  created_at: string;
+}
+
+export interface RerunSkillRequest {
+  evaluation_id: string;
+  skill_id?: string | null;
+  evaluators?: EvaluatorType[];
+  infer_corrections?: boolean;
+  n_samples?: number;
+}
+
+export interface RerunSkillResponse {
+  evaluation_id: string;
+  skill_id: string;
+  status: string;
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -708,24 +708,6 @@ export interface AgentSkill {
 // --- Evaluation types ---
 
 export type EvaluationSourceType = "agent" | "request_domain" | "skill";
-export type EvaluatorType =
-  | "field_accuracy"
-  | "fuzzy_field_match"
-  | "llm_judge"
-  | "equals_expected";
-
-export interface RunEvaluationRequest {
-  source_type: EvaluationSourceType;
-  source_id: string;
-  source_label: string;
-  execution_ids?: string[] | null;
-  request_ids?: string[] | null;
-  skill_ids?: string[] | null;
-  data_from?: string | null;
-  data_to?: string | null;
-  evaluators?: EvaluatorType[] | null;
-  infer_corrections?: boolean | null;
-}
 
 export interface EvaluationRunResponse {
   id: string;
@@ -814,37 +796,4 @@ export interface UniqueSource {
 
 export interface EvaluationUniqueSourcesResponse {
   sources: UniqueSource[];
-}
-
-export interface OptimizeSkillRequest {
-  skill_id: string;
-  skill_ids?: string[] | null;
-  data_from?: string | null;
-  data_to?: string | null;
-  infer_corrections?: boolean;
-  n_samples?: number;
-}
-
-export interface OptimizeSkillResponse {
-  skill_id: string;
-  name: string;
-  version: string;
-  original_skill_id: string;
-  total_pairs: number;
-  sampled_pairs: number;
-  created_at: string;
-}
-
-export interface RerunSkillRequest {
-  evaluation_id: string;
-  skill_id?: string | null;
-  evaluators?: EvaluatorType[];
-  infer_corrections?: boolean;
-  n_samples?: number;
-}
-
-export interface RerunSkillResponse {
-  evaluation_id: string;
-  skill_id: string;
-  status: string;
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -797,3 +797,25 @@ export interface UniqueSource {
 export interface EvaluationUniqueSourcesResponse {
   sources: UniqueSource[];
 }
+
+export interface EvaluationListOptions {
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  descending?: boolean;
+  createdAtGte?: string;
+  createdAtLte?: string;
+}
+
+export interface EvaluationPreviewOptions {
+  sourceType: EvaluationSourceType;
+  sourceId: string;
+  dataFrom?: string;
+  dataTo?: string;
+}
+
+export interface EvaluationMetricsOptions {
+  limit?: number;
+  sourceType?: string;
+  sourceLabel?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { Skills } from "./client/skills";
 import { Executions } from "./client/executions";
 import { Domains } from "./client/domains";
 import { Artifacts } from "./client/artifacts";
+import { Evaluations } from "./client/evaluations";
 
 export * from "./client/types";
 export * from "./client/base_requestor";
@@ -31,6 +32,7 @@ export * from "./client/agent";
 export * from "./client/skills";
 export * from "./client/executions";
 export * from "./client/artifacts";
+export * from "./client/evaluations";
 
 export * from "./utils";
 
@@ -61,6 +63,7 @@ export class VlmRun {
   readonly executions: Executions;
   readonly domains: Domains;
   readonly artifacts: Artifacts;
+  readonly evaluations: Evaluations;
 
   constructor(config: VlmRunConfig) {
     this.client = {
@@ -88,6 +91,7 @@ export class VlmRun {
     this.executions = new Executions(this.client);
     this.domains = new Domains(this.client);
     this.artifacts = new Artifacts(this.client);
+    this.evaluations = new Evaluations(this.client);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a new `Evaluations` resource to the Node SDK, exposing read-only evaluation API endpoints. This includes:

- **`evaluations.ts`**: New resource class with 7 methods — `list`, `get`, `preview`, `metrics`, `summaryStats`, `uniqueSources`, `delete`
- **`types.ts`**: 15 new TypeScript interfaces/types for evaluation models (`EvaluationRunResponse`, `EvaluationMetricsResponse`, `EvaluationListOptions`, etc.)
- **`index.ts`**: Wires `Evaluations` into the `VlmRun` client class and re-exports

The implementation follows the same patterns as existing resources (Feedback, Artifacts, etc.), using `APIRequestor` for HTTP calls.

### Updates since last revision
- **Removed write operations** (`run`, `optimizeSkill`, `rerunSkill`) and their associated request/response types per reviewer feedback — only endpoints available in vlm-lab are included
- **Extracted inline parameter types** into named interfaces (`EvaluationListOptions`, `EvaluationPreviewOptions`, `EvaluationMetricsOptions`) per gemini-code-assist review

## Review & Testing Checklist for Human

- [ ] **Validate type definitions against the actual backend API schema**: Types were inferred from vlm-cloud frontend usage, not from the backend OpenAPI spec. Check that field names, types, and nullability (especially `results: Record<string, any>`, nullable fields like `source_id`, `accuracy`) match the real API contract.
- [ ] **Verify query parameter naming**: Confirm that snake_case mappings like `created_at__gte`, `source_type`, `source_label` match the actual API query parameter names.
- [ ] **No unit tests included**: Consider whether tests should be added for the new resource before merging.
- [ ] **Test end-to-end**: Instantiate `VlmRun` client, call `client.evaluations.list()` and `client.evaluations.metrics()` against a dev/staging environment to confirm the responses deserialize correctly.

### Notes
- Hardcoded defaults: `list()` defaults to `limit=30`, `offset=0`, `order_by="created_at"`, `descending=true`. `metrics()` defaults to `limit=20`. Verify these are appropriate.
- The `security` CI check failure is pre-existing (npm audit vulnerabilities in transitive dependencies) and unrelated to this PR.
- A corresponding Python SDK PR is available at https://github.com/vlm-run/vlmrun-python-sdk/pull/183.

Link to Devin session: https://app.devin.ai/sessions/e8157dfb67844254bf3d6c358c57ebe5
Requested by: @Mirajul-Mohin
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
