### PR TITLE
feat: expose videoSegmentDuration, videoFramesPerSegment, and pageIndices in GenerationConfig

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -297,6 +297,9 @@ export type GenerationConfigParams = {
   confidence?: boolean;
   grounding?: boolean;
   gqlStmt?: string | null;
+  videoSegmentDuration?: number;
+  videoFramesPerSegment?: number;
+  pageIndices?: number[];
 };
 
 export class GenerationConfig {
@@ -325,6 +328,21 @@ export class GenerationConfig {
    */
   gqlStmt: string | null = null;
 
+  /**
+   * Duration in seconds for each video segment when chunking a video for transcription.
+   */
+  videoSegmentDuration?: number;
+
+  /**
+   * Number of frames to sample per video segment for captioning.
+   */
+  videoFramesPerSegment?: number;
+
+  /**
+   * 0-indexed page indices to process for document files. If undefined, all pages are processed.
+   */
+  pageIndices?: number[];
+
   constructor(params: Partial<GenerationConfig> = {}) {
     Object.assign(this, params);
   }
@@ -339,6 +357,9 @@ export class GenerationConfig {
       confidence: this.confidence,
       grounding: this.grounding,
       gql_stmt: this.gqlStmt,
+      ...(this.videoSegmentDuration !== undefined && { video_segment_duration: this.videoSegmentDuration }),
+      ...(this.videoFramesPerSegment !== undefined && { video_frames_per_segment: this.videoFramesPerSegment }),
+      ...(this.pageIndices !== undefined && { page_indices: this.pageIndices }),
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds three new optional parameters to `GenerationConfig` (and `GenerationConfigParams`) to expose server-side video transcription and document processing controls:

- **`videoSegmentDuration`** (`number`): Duration in seconds for each video segment when chunking for transcription (maps to `video_segment_duration`)
- **`videoFramesPerSegment`** (`number`): Number of frames to sample per video segment (maps to `video_frames_per_segment`)
- **`pageIndices`** (`number[]`): 0-indexed page indices to selectively process document pages (maps to `page_indices`)

These are conditionally included in `toJSON()` only when set, to avoid sending unnecessary defaults to the API.

Companion PRs: vlm-lab (adds `page_indices` to backend `GenerationConfig`) and vlmrun-python-sdk (same fields in Python SDK).

## Review & Testing Checklist for Human
- [ ] Verify the conditional spread pattern in `toJSON()` (lines 357-359) correctly omits fields when `undefined` — note this differs from existing fields which are always serialized. Confirm this is the desired behavior with the backend.
- [ ] Confirm no client-side validation is needed for `videoSegmentDuration >= 1.0` and `videoFramesPerSegment >= 1` (backend enforces these constraints)

### Notes
- No tests added — these are type-level additions with straightforward serialization logic
- The `GenerationConfigParams` type and `GenerationConfig` class both updated to keep them in sync

Link to Devin session: https://app.devin.ai/sessions/2f2d14e8cb55450c80d380356f9899b6
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
