### PR TITLE
feat: add videoSegmentDuration, videoFramesPerSegment, and pageIndices to GenerationConfig

### DIFF
--- a/src/client/predictions.ts
+++ b/src/client/predictions.ts
@@ -209,6 +209,9 @@ export class ImagePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          video_segment_duration: config?.videoSegmentDuration ?? null,
+          video_frames_per_segment: config?.videoFramesPerSegment ?? null,
+          page_indices: config?.pageIndices ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -332,6 +335,9 @@ export class FilePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          video_segment_duration: config?.videoSegmentDuration ?? null,
+          video_frames_per_segment: config?.videoFramesPerSegment ?? null,
+          page_indices: config?.pageIndices ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -397,6 +403,9 @@ export class FilePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          video_segment_duration: config?.videoSegmentDuration ?? null,
+          video_frames_per_segment: config?.videoFramesPerSegment ?? null,
+          page_indices: config?.pageIndices ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -460,6 +469,9 @@ export class WebPredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          video_segment_duration: config?.videoSegmentDuration ?? null,
+          video_frames_per_segment: config?.videoFramesPerSegment ?? null,
+          page_indices: config?.pageIndices ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -297,6 +297,9 @@ export type GenerationConfigParams = {
   confidence?: boolean;
   grounding?: boolean;
   gqlStmt?: string | null;
+  videoSegmentDuration?: number | null;
+  videoFramesPerSegment?: number | null;
+  pageIndices?: number[] | null;
 };
 
 export class GenerationConfig {
@@ -325,6 +328,21 @@ export class GenerationConfig {
    */
   gqlStmt: string | null = null;
 
+  /**
+   * Duration in seconds for each video segment when chunking a video for transcription.
+   */
+  videoSegmentDuration: number | null = null;
+
+  /**
+   * Number of frames to sample per video segment for captioning.
+   */
+  videoFramesPerSegment: number | null = null;
+
+  /**
+   * 0-indexed page indices to process for document files. If null, all pages are processed.
+   */
+  pageIndices: number[] | null = null;
+
   constructor(params: Partial<GenerationConfig> = {}) {
     Object.assign(this, params);
   }
@@ -339,6 +357,9 @@ export class GenerationConfig {
       confidence: this.confidence,
       grounding: this.grounding,
       gql_stmt: this.gqlStmt,
+      video_segment_duration: this.videoSegmentDuration,
+      video_frames_per_segment: this.videoFramesPerSegment,
+      page_indices: this.pageIndices,
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds three new fields to `GenerationConfig` and `GenerationConfigParams` to match recent backend additions in vlm-lab ([#1790](https://github.com/vlm-run/vlm-lab/pull/1790), [#1791](https://github.com/vlm-run/vlm-lab/pull/1791)):

- `videoSegmentDuration` → `video_segment_duration`: duration in seconds per video chunk (default on server: 30)
- `videoFramesPerSegment` → `video_frames_per_segment`: frames sampled per chunk (default on server: 8)
- `pageIndices` → `page_indices`: 0-indexed pages to process for documents (null = all pages)

All three are propagated through `toJSON()` and through the hardcoded config objects in every prediction endpoint (`ImagePredictions`, `FilePredictions`, `WebPredictions`).

## Review & Testing Checklist for Human

- [ ] **Null field handling**: All three fields are always sent as `null` when not set. Verify the API accepts `null` for these fields across all endpoints (image, document, video, audio, web). The Python SDK uses `exclude_none=True` and omits unset fields entirely — this SDK does not, which could cause issues.
- [ ] **Irrelevant fields on wrong endpoints**: `videoSegmentDuration`/`videoFramesPerSegment` are sent to image and document endpoints; `pageIndices` is sent to video/audio/web endpoints. Confirm the API ignores unrecognized config fields rather than rejecting them.
- [ ] **No unit tests added**: Consider adding a test that verifies `new GenerationConfig({ videoSegmentDuration: 15, pageIndices: [0, 2] }).toJSON()` produces the correct snake_case output.

### Notes
- The Python SDK (`vlmrun-python-sdk`) already has all three fields.
- Server-side validation enforces `≥ 1` for both video fields; the Node SDK does no client-side validation.

Link to Devin session: https://app.devin.ai/sessions/fda3707595034089a20e6f889a690497
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
