### PR TITLE
feat(pricing): add `serviceTier` to `GenerationConfig`

### DIFF
--- a/src/client/predictions.ts
+++ b/src/client/predictions.ts
@@ -209,6 +209,7 @@ export class ImagePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          service_tier: config?.serviceTier ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -332,6 +333,7 @@ export class FilePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          service_tier: config?.serviceTier ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -397,6 +399,7 @@ export class FilePredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          service_tier: config?.serviceTier ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",
@@ -460,6 +463,7 @@ export class WebPredictions extends Predictions {
           confidence: config?.confidence ?? false,
           grounding: config?.grounding ?? false,
           gql_stmt: config?.gqlStmt ?? null,
+          service_tier: config?.serviceTier ?? null,
         },
         metadata: {
           environment: metadata?.environment ?? "dev",

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -289,6 +289,13 @@ export class RequestMetadata {
 
 export type RequestMetadataInput = RequestMetadata | RequestMetadataParams;
 
+export type ServiceTier =
+  | "auto"
+  | "default"
+  | "standard"
+  | "flex"
+  | "priority";
+
 export type GenerationConfigParams = {
   detail?: "auto" | "hi" | "lo";
   responseModel?: ZodType;
@@ -297,6 +304,7 @@ export type GenerationConfigParams = {
   confidence?: boolean;
   grounding?: boolean;
   gqlStmt?: string | null;
+  serviceTier?: ServiceTier | null;
 };
 
 export class GenerationConfig {
@@ -325,6 +333,20 @@ export class GenerationConfig {
    */
   gqlStmt: string | null = null;
 
+  /**
+   * Delivery tier for the request, mirroring OpenAI's `service_tier` semantics
+   * and Vertex AI's Gemini Flex/Priority offering.
+   *
+   * - `"standard"` / `"default"`: baseline rates (1.0x).
+   * - `"flex"`: 50% discount with higher latency (0.5x).
+   * - `"priority"`: 1.8x premium for highest reliability.
+   * - `"auto"` / `null`: fall back to the server-side default
+   *   (currently `"standard"`).
+   *
+   * The chosen tier drives BOTH billing AND the underlying request routing.
+   */
+  serviceTier: ServiceTier | null = null;
+
   constructor(params: Partial<GenerationConfig> = {}) {
     Object.assign(this, params);
   }
@@ -339,6 +361,7 @@ export class GenerationConfig {
       confidence: this.confidence,
       grounding: this.grounding,
       gql_stmt: this.gqlStmt,
+      service_tier: this.serviceTier,
     };
   }
 }

--- a/tests/unit/client/audio-predictions.test.ts
+++ b/tests/unit/client/audio-predictions.test.ts
@@ -48,6 +48,7 @@ describe("AudioPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -97,6 +98,7 @@ describe("AudioPredictions", () => {
             detail: "hi",
             grounding: true,
             gql_stmt: null,
+            service_tier: null,
           },
           metadata: {
             environment: "prod",
@@ -133,6 +135,7 @@ describe("AudioPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -182,6 +185,7 @@ describe("AudioPredictions", () => {
             detail: "lo",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -244,6 +248,7 @@ describe("AudioPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {

--- a/tests/unit/client/predictions.test.ts
+++ b/tests/unit/client/predictions.test.ts
@@ -120,6 +120,7 @@ describe("Predictions", () => {
               confidence: false,
               detail: "auto",
               gql_stmt: null,
+              service_tier: null,
               grounding: false,
               json_schema: undefined,
             },
@@ -166,6 +167,7 @@ describe("Predictions", () => {
               confidence: false,
               detail: "auto",
               gql_stmt: null,
+              service_tier: null,
               grounding: false,
               json_schema: { type: "object" },
             },
@@ -313,6 +315,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -350,6 +353,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -510,6 +514,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -547,6 +552,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -633,6 +639,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -670,6 +677,7 @@ describe("Predictions", () => {
               detail: "auto",
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
               json_schema: undefined,
             },
             metadata: {
@@ -766,6 +774,7 @@ describe("Predictions", () => {
               confidence: false,
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
             },
             metadata: {
               environment: "prod",
@@ -807,6 +816,7 @@ describe("Predictions", () => {
               confidence: false,
               grounding: false,
               gql_stmt: null,
+              service_tier: null,
             },
             metadata: {
               environment: "dev",
@@ -914,6 +924,7 @@ describe("Predictions", () => {
               json_schema: null,
               confidence: false,
               gql_stmt: null,
+              service_tier: null,
               grounding: false,
             },
             metadata: {
@@ -966,6 +977,7 @@ describe("Predictions", () => {
               json_schema: { type: "object" },
               confidence: true,
               gql_stmt: null,
+              service_tier: null,
               grounding: true,
             },
             metadata: {

--- a/tests/unit/client/video-predictions.test.ts
+++ b/tests/unit/client/video-predictions.test.ts
@@ -48,6 +48,7 @@ describe("VideoPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -97,6 +98,7 @@ describe("VideoPredictions", () => {
             detail: "hi",
             grounding: true,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -134,6 +136,7 @@ describe("VideoPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -183,6 +186,7 @@ describe("VideoPredictions", () => {
             detail: "lo",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {
@@ -245,6 +249,7 @@ describe("VideoPredictions", () => {
             detail: "auto",
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
             json_schema: undefined,
           },
           metadata: {

--- a/tests/unit/client/vlmrun.test.ts
+++ b/tests/unit/client/vlmrun.test.ts
@@ -114,9 +114,41 @@ describe("Domains class methods", () => {
             confidence: true,
             grounding: false,
             gql_stmt: null,
+            service_tier: null,
           }
         }
       );
+    });
+  });
+
+  describe("GenerationConfig service_tier", () => {
+    it.each(["auto", "default", "standard", "flex", "priority"] as const)(
+      "accepts %s and serialises it as service_tier",
+      (tier) => {
+        const config = new GenerationConfig({ serviceTier: tier });
+        expect(config.serviceTier).toBe(tier);
+        expect(config.toJSON()).toEqual({
+          detail: "auto",
+          json_schema: null,
+          confidence: false,
+          grounding: false,
+          gql_stmt: null,
+          service_tier: tier,
+        });
+      }
+    );
+
+    it("defaults to null and serialises service_tier as null", () => {
+      const config = new GenerationConfig();
+      expect(config.serviceTier).toBeNull();
+      expect(config.toJSON()).toEqual({
+        detail: "auto",
+        json_schema: null,
+        confidence: false,
+        grounding: false,
+        gql_stmt: null,
+        service_tier: null,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Mirrors [vlm-run/vlm-lab#1826](https://github.com/vlm-run/vlm-lab/pull/1826) in the Node.js SDK.

Adds a new optional `serviceTier` field to `GenerationConfig` (and `GenerationConfigParams`) so callers can opt into Flex/Priority pricing on any `image|document|video|audio.generate(..)` / `.execute(..)` request. The SDK forwards it to the server as `service_tier`; the server then applies the corresponding billing multiplier and routes the underlying call to the correct tier.

**Tiers:**
- `"standard"` / `"default"` — 1.0× rate (server default)
- `"flex"` — 0.5× rate (50% discount, higher latency)
- `"priority"` — 1.8× rate (higher premium, highest reliability)
- `"auto"` / `null` — falls back to the server-side default (currently `"standard"`)

### Changes
- `src/client/types.ts`: added `ServiceTier` union type, `serviceTier` field on `GenerationConfigParams` and `GenerationConfig` class, and wired it through `toJSON()` as `service_tier`.
- `tests/unit/client/vlmrun.test.ts`: added coverage for all accepted tier values + default (`null`) serialization, and updated the existing `getSchema` test to reflect the new field in the serialized payload.

### Usage

```typescript
import { VlmRun } from "vlmrun";
import { GenerationConfig } from "vlmrun/client/types";

// 50% off (flex)
const response = await client.document.generate({
  url: "https://example.com/invoice.pdf",
  domain: "document.invoice",
  config: new GenerationConfig({ serviceTier: "flex" }),
});

// Highest reliability (priority)
const response = await client.image.generate({
  images: [image],
  domain: "document.invoice",
  config: { serviceTier: "priority" },
});
```

## Review & Testing Checklist for Human

- [ ] Confirm the `ServiceTier` literal values match the server-side contract in [vlm-run/vlm-lab#1826](https://github.com/vlm-run/vlm-lab/pull/1826) (`auto`, `default`, `standard`, `flex`, `priority`).
- [ ] End-to-end smoke test: issue a `document.generate(..., { config: { serviceTier: "flex" } })` against a `flex`-enabled deployment and verify the returned `usage.credits_used` is ~50% of the `standard` baseline.
- [ ] Confirm existing callers that don't set `serviceTier` see no behavioural change (the field serializes as `service_tier: null`, which the server treats identically to "omitted / auto").

### Notes
- `toJSON()` now always emits `service_tier` (defaulting to `null`). The server-side contract in #1826 treats `null` / `"auto"` identically to the omitted case, so this is backwards-compatible.
- No client-side validation of the tier beyond the TS `Literal` union — server remains the source of truth for which tiers are enabled per account.

Link to Devin session: https://app.devin.ai/sessions/0a5a9297f1214c94ab6c9fb253bfd560
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
