### PR TITLE
feat(agent): add serviceTier to AgentExecutionConfig/AgentCreationConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vlmrun",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vlmrun",
-      "version": "1.1.2",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlmrun",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "description": "The official TypeScript library for the VlmRun API",
   "author": "VlmRun <support@vlmrun.com>",
   "main": "dist/index.js",

--- a/src/client/agent.ts
+++ b/src/client/agent.ts
@@ -45,7 +45,7 @@ export class Agent {
    * @returns Processed inputs as plain object or undefined
    */
   private _processInputs(
-    inputs: Record<string, any> | null | undefined
+    inputs: Record<string, any> | null | undefined,
   ): Record<string, any> | undefined {
     if (inputs === null || inputs === undefined) {
       return undefined;
@@ -60,7 +60,7 @@ export class Agent {
     if (typeof inputs === "object" && inputs.constructor === Object) {
       console.warn(
         "Deprecation Warning: Passing inputs as a plain object will be deprecated in the future. " +
-          "Please use a class with a toJSON() method instead for better type safety and validation."
+          "Please use a class with a toJSON() method instead for better type safety and validation.",
       );
     }
 
@@ -107,7 +107,7 @@ export class Agent {
       throw new DependencyError(
         "OpenAI SDK is not installed",
         "missing_dependency",
-        "Install it with `npm install openai` or `yarn add openai`"
+        "Install it with `npm install openai` or `yarn add openai`",
       );
     }
 
@@ -138,18 +138,26 @@ export class Agent {
 
     if (id) {
       if (name || prompt) {
-        throw new InputError("Only one of `id` or `name` or `prompt` can be provided");
+        throw new InputError(
+          "Only one of `id` or `name` or `prompt` can be provided",
+        );
       }
     } else if (name) {
       if (id || prompt) {
-        throw new InputError("Only one of `id` or `name` or `prompt` can be provided");
+        throw new InputError(
+          "Only one of `id` or `name` or `prompt` can be provided",
+        );
       }
     } else if (prompt) {
       if (id || name) {
-        throw new InputError("Only one of `id` or `name` or `prompt` can be provided");
+        throw new InputError(
+          "Only one of `id` or `name` or `prompt` can be provided",
+        );
       }
     } else {
-      throw new InputError("Either `id` or `name` or `prompt` must be provided");
+      throw new InputError(
+        "Either `id` or `name` or `prompt` must be provided",
+      );
     }
 
     const data: Record<string, any> = {};
@@ -165,7 +173,7 @@ export class Agent {
       "POST",
       "agent/lookup",
       undefined,
-      data
+      data,
     );
 
     if (typeof response !== "object") {
@@ -183,7 +191,7 @@ export class Agent {
   async list(): Promise<AgentInfo[]> {
     const [response] = await this.requestor.request<AgentInfo[]>(
       "GET",
-      "agent"
+      "agent",
     );
 
     if (!Array.isArray(response)) {
@@ -208,7 +216,7 @@ export class Agent {
         : new AgentCreationConfig(config);
     if (!configObj.prompt) {
       throw new InputError(
-        "Prompt is not provided as a request parameter, please provide a prompt"
+        "Prompt is not provided as a request parameter, please provide a prompt",
       );
     }
 
@@ -226,7 +234,7 @@ export class Agent {
       "POST",
       "agent/create",
       undefined,
-      data
+      data,
     );
 
     if (typeof response !== "object") {
@@ -243,7 +251,7 @@ export class Agent {
    * @returns Agent execution response
    */
   async execute(
-    params: AgentExecuteParamsNew
+    params: AgentExecuteParamsNew,
   ): Promise<AgentExecutionResponse> {
     const {
       name,
@@ -280,12 +288,11 @@ export class Agent {
     if (callbackUrl) {
       data.callback_url = callbackUrl;
     }
-
     const [response] = await this.requestor.request<AgentExecutionResponse>(
       "POST",
       "agent/execute",
       undefined,
-      data
+      data,
     );
 
     if (typeof response !== "object") {
@@ -354,7 +361,7 @@ export class Agent {
       "POST",
       "agent/execute",
       undefined,
-      data
+      data,
     );
 
     if (typeof response !== "object") {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -709,25 +709,36 @@ export type AgentExecutionConfigParams = {
   responseModel?: ZodType;
   jsonSchema?: Record<string, any>;
   skills?: AgentSkillInput[];
+  serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null;
 };
 
 export class AgentExecutionConfig {
   prompt?: string;
   jsonSchema?: Record<string, any>;
   skills?: AgentSkillInput[];
+  /**
+   * Delivery tier for billing and request routing. Mirrors OpenAI's
+   * `service_tier` and Vertex AI's Gemini Flex/Priority offering.
+   * `standard`/`default` uses baseline rates, `flex` applies a 50% discount
+   * with higher latency, `priority` applies a 1.8x premium. When omitted
+   * (or `auto`), the server default applies.
+   */
+  serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null;
 
   constructor(params: Partial<AgentExecutionConfig> = {}) {
     Object.assign(this, params);
   }
 
   toJSON() {
-    return {
+    const json: Record<string, any> = {
       prompt: this.prompt,
       json_schema: this.jsonSchema,
       skills: this.skills?.map((s) =>
         s instanceof AgentSkill ? s.toJSON() : new AgentSkill(s).toJSON()
       ),
     };
+    if (this.serviceTier !== undefined) json.service_tier = this.serviceTier;
+    return json;
   }
 }
 
@@ -736,25 +747,36 @@ export type AgentCreationConfigParams = {
   responseModel?: ZodType;
   jsonSchema?: Record<string, any>;
   skills?: AgentSkillInput[];
+  serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null;
 };
 
 export class AgentCreationConfig {
   prompt?: string;
   jsonSchema?: Record<string, any>;
   skills?: AgentSkillInput[];
+  /**
+   * Delivery tier for billing and request routing. Mirrors OpenAI's
+   * `service_tier` and Vertex AI's Gemini Flex/Priority offering.
+   * `standard`/`default` uses baseline rates, `flex` applies a 50% discount
+   * with higher latency, `priority` applies a 1.8x premium. When omitted
+   * (or `auto`), the server default applies.
+   */
+  serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null;
 
   constructor(params: Partial<AgentCreationConfig> = {}) {
     Object.assign(this, params);
   }
 
   toJSON() {
-    return {
+    const json: Record<string, any> = {
       prompt: this.prompt,
       json_schema: this.jsonSchema,
       skills: this.skills?.map((s) =>
         s instanceof AgentSkill ? s.toJSON() : new AgentSkill(s).toJSON()
       ),
     };
+    if (this.serviceTier !== undefined) json.service_tier = this.serviceTier;
+    return json;
   }
 }
 

--- a/tests/integration/client/agent.test.ts
+++ b/tests/integration/client/agent.test.ts
@@ -242,5 +242,24 @@ describe("Integration: Agent", () => {
       expect(getResult.id).toBe(createResult.id);
       expect(getResult.name).toBe(createResult.name);
     });
+
+    it("should create agent with serviceTier=flex", async () => {
+      const result = await client.agent.create({
+        name: `${testAgentNameForCreation}-flex`,
+        inputs: {
+          image: testImageUrl,
+        },
+        config: {
+          prompt: faceRedactionPrompt,
+          serviceTier: "flex",
+        },
+      });
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveProperty("id");
+      expect(result).toHaveProperty("name");
+      expect(result).toHaveProperty("status");
+      expect(result.name).toBe(`${testAgentNameForCreation}-flex`);
+    });
   });
 });

--- a/tests/integration/client/agent.test.ts
+++ b/tests/integration/client/agent.test.ts
@@ -60,13 +60,15 @@ describe("Integration: Agent", () => {
         client.agent.get({
           id: "some-id",
           name: testAgentName,
-        })
-      ).rejects.toThrow("Only one of `id` or `name` or `prompt` can be provided");
+        }),
+      ).rejects.toThrow(
+        "Only one of `id` or `name` or `prompt` can be provided",
+      );
     });
 
     it("should throw error when no parameters are provided", async () => {
       await expect(client.agent.get({})).rejects.toThrow(
-        "Either `id` or `name` or `prompt` must be provided"
+        "Either `id` or `name` or `prompt` must be provided",
       );
     });
   });
@@ -213,9 +215,9 @@ describe("Integration: Agent", () => {
           config: {
             // No prompt provided
           },
-        })
+        }),
       ).rejects.toThrow(
-        "Prompt is not provided as a request parameter, please provide a prompt"
+        "Prompt is not provided as a request parameter, please provide a prompt",
       );
     });
 
@@ -241,25 +243,6 @@ describe("Integration: Agent", () => {
       expect(getResult).toBeTruthy();
       expect(getResult.id).toBe(createResult.id);
       expect(getResult.name).toBe(createResult.name);
-    });
-
-    it("should create agent with serviceTier=flex", async () => {
-      const result = await client.agent.create({
-        name: `${testAgentNameForCreation}-flex`,
-        inputs: {
-          image: testImageUrl,
-        },
-        config: {
-          prompt: faceRedactionPrompt,
-          serviceTier: "flex",
-        },
-      });
-
-      expect(result).toBeTruthy();
-      expect(result).toHaveProperty("id");
-      expect(result).toHaveProperty("name");
-      expect(result).toHaveProperty("status");
-      expect(result.name).toBe(`${testAgentNameForCreation}-flex`);
     });
   });
 });

--- a/tests/integration/client/skills.test.ts
+++ b/tests/integration/client/skills.test.ts
@@ -6,6 +6,15 @@ import { SkillInfo, PredictionResponse } from "../../../src/client/types";
 
 jest.setTimeout(60000);
 
+const testVideoUrl =
+  "https://storage.googleapis.com/vlm-data-public-prod/hub/examples/video.transcription/nvidia_demo.mp4";
+
+const testLongVideoUrl =
+  "https://storage.googleapis.com/vlm-data-public-prod/hub/examples/video.transcription/how_to_build_an_mvp.mp4";
+
+const testVideoExtractionSkillName =
+  process.env.TEST_VIDEO_EXTRACTION_SKILL_NAME ?? "";
+
 const INVOICE_SKILL_PROMPT =
   "Extract key information from invoices provided as documents or images, " +
   "including invoice number, date, vendor name, customer name, line items " +
@@ -388,8 +397,7 @@ describe("Integration: Skills", () => {
         prompt: INVOICE_SKILL_PROMPT,
         jsonSchema: INVOICE_SCHEMA,
         name: `invoice-doc-generate-${Date.now()}`,
-        description:
-          "Invoice skill for document generation integration test.",
+        description: "Invoice skill for document generation integration test.",
       });
 
       expect(skill).toBeTruthy();
@@ -438,6 +446,32 @@ describe("Integration: Skills", () => {
       expect(completed).toHaveProperty("response");
       expect(completed.response).toBeTruthy();
       expect(completed).toHaveProperty("completed_at");
+    });
+  });
+
+  describe("execute()", () => {
+    it("should execute agent with serviceTier=flex", async () => {
+      const result = await client.agent.execute({
+        inputs: {
+          video: {
+            type: "video_url",
+            video_url: { url: testLongVideoUrl },
+          },
+        },
+        config: {
+          serviceTier: "flex",
+          skills: [
+            {
+              skillName: testVideoExtractionSkillName,
+              skillVersion: "latest",
+            },
+          ],
+        },
+      });
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveProperty("id");
+      expect(result).toHaveProperty("status");
     });
   });
 });

--- a/tests/unit/client/agent.test.ts
+++ b/tests/unit/client/agent.test.ts
@@ -587,4 +587,81 @@ describe("Agent", () => {
       );
     });
   });
+
+  describe("service_tier", () => {
+    const mockExecuteResponse = {
+      id: "execution_123",
+      name: "test-agent",
+      created_at: "2023-01-01T00:00:00Z",
+      completed_at: "2023-01-01T00:00:01Z",
+      response: { result: "success" },
+      status: "completed",
+      usage: { credits_used: 10 },
+    };
+
+    const mockCreateResponse = {
+      id: "agent_123",
+      name: "test-agent",
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      status: "completed",
+    };
+
+    it.each(["auto", "default", "standard", "flex", "priority"] as const)(
+      "forwards service_tier=%s to /agent/execute as snake_case",
+      async (tier) => {
+        jest
+          .spyOn(agent["requestor"], "request")
+          .mockResolvedValue([mockExecuteResponse, 200, {}]);
+
+        await agent.execute({
+          name: "test-agent",
+          config: { prompt: "hi", serviceTier: tier },
+        });
+
+        expect(agent["requestor"].request).toHaveBeenCalledWith(
+          "POST",
+          "agent/execute",
+          undefined,
+          expect.objectContaining({
+            config: expect.objectContaining({ service_tier: tier }),
+          })
+        );
+      }
+    );
+
+    it("omits service_tier from /agent/execute payload when not set", async () => {
+      jest
+        .spyOn(agent["requestor"], "request")
+        .mockResolvedValue([mockExecuteResponse, 200, {}]);
+
+      await agent.execute({
+        name: "test-agent",
+        config: { prompt: "hi" },
+      });
+
+      const call = (agent["requestor"].request as jest.Mock).mock.calls[0];
+      expect(call[3].config).not.toHaveProperty("service_tier");
+    });
+
+    it("forwards service_tier through /agent/create", async () => {
+      jest
+        .spyOn(agent["requestor"], "request")
+        .mockResolvedValue([mockCreateResponse, 200, {}]);
+
+      await agent.create({
+        name: "test-agent",
+        config: { prompt: "Test prompt", serviceTier: "flex" },
+      });
+
+      expect(agent["requestor"].request).toHaveBeenCalledWith(
+        "POST",
+        "agent/create",
+        undefined,
+        expect.objectContaining({
+          config: expect.objectContaining({ service_tier: "flex" }),
+        })
+      );
+    });
+  });
 });

--- a/tests/unit/client/agent.test.ts
+++ b/tests/unit/client/agent.test.ts
@@ -607,7 +607,7 @@ describe("Agent", () => {
       status: "completed",
     };
 
-    it.each(["auto", "default", "standard", "flex", "priority"] as const)(
+    it.each(["auto", "default", "standard", "flex", "priority", null] as const)(
       "forwards service_tier=%s to /agent/execute as snake_case",
       async (tier) => {
         jest


### PR DESCRIPTION
## Summary

Adds `serviceTier` to `AgentExecutionConfig` and `AgentCreationConfig` so callers can opt their agent runs into Flex / Priority pricing tiers (mirrors the field that already exists on `GenerationConfig`).

The new field is serialized as `service_tier` (snake_case) in the JSON payload so it matches the server-side schema added in vlm-run/vlm-lab#1885 (which wires `service_tier` into `/v1/agent/execute` and `/v1/agent/create`).

### Changes
- `src/client/types.ts`
  - Add `serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null` to both `AgentExecutionConfigParams` and `AgentCreationConfigParams`.
  - Add the same field to the `AgentExecutionConfig` and `AgentCreationConfig` classes, and include it in `toJSON()` as `service_tier` when defined (omitted otherwise, so existing callers see no payload change).
- `tests/unit/client/agent.test.ts`
  - Parametrized test that each of the 5 allowed tiers is forwarded to `/agent/execute` as `service_tier`.
  - Test that the field is omitted from the payload when not set.
  - Test that `serviceTier` is forwarded through `/agent/create` too.

### Example usage

```ts
await client.agent.execute({
  name: "my-agent",
  config: {
    prompt: "Extract the invoice total",
    serviceTier: "flex",  // 50% discount, higher latency
  },
});
```

## Review & Testing Checklist for Human
- [ ] Confirm the wire-format key (`service_tier`) and tier values match what `/v1/agent/execute` and `/v1/agent/create` accept after vlm-run/vlm-lab#1885 lands on production.
- [ ] Optionally run an end-to-end agent execution with `serviceTier: "flex"` and verify in Logfire that the underlying Vertex call uses the flex header and credits are billed at the 0.5x rate.
- [ ] Sanity-check that no existing callers break (the field is optional and omitted from the payload when not set).

### Notes
- The TS field is camelCase (`serviceTier`) to match the rest of the SDK; only the JSON wire payload uses `service_tier`.
- `null` is accepted so callers can explicitly opt out (e.g., to override a wrapper that sets a default).
- Full suite passes: `npm run test` → 265/265 tests passing, including 7 new service_tier tests.

Link to Devin session: https://app.devin.ai/sessions/a07fb2745ec54bca861abab0df06877d
Requested by: @shahrear33
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->