### PR TITLE
fix: increase agent execute and chat completions timeouts to ≥600s

### DIFF
--- a/src/client/agent.ts
+++ b/src/client/agent.ts
@@ -115,7 +115,7 @@ export class Agent {
     const openaiClient = new OpenAI({
       apiKey: this.client.apiKey,
       baseURL: baseUrl,
-      timeout: this.client.timeout,
+      timeout: Math.max(this.client.timeout ?? 600000, 600000),
       maxRetries: this.client.maxRetries ?? 1,
     });
 

--- a/src/client/executions.ts
+++ b/src/client/executions.ts
@@ -8,7 +8,7 @@ export class Executions {
 
   constructor(client: Client) {
     this.client = client;
-    this.requestor = new APIRequestor({ ...client, timeout: 120000 });
+    this.requestor = new APIRequestor({ ...client, timeout: 600000 });
   }
 
   /**
@@ -49,14 +49,14 @@ export class Executions {
    * Wait for execution to complete.
    * 
    * @param id - ID of execution to wait for
-   * @param timeout - Maximum number of seconds to wait (default: 300)
+   * @param timeout - Maximum number of seconds to wait (default: 600)
    * @param sleep - Time to wait between checks in seconds (default: 5)
    * @returns Completed execution
    * @throws RequestTimeoutError if execution does not complete within timeout
    */
   async wait(
     id: string,
-    timeout: number = 300,
+    timeout: number = 600,
     sleep: number = 5
   ): Promise<AgentExecutionResponse> {
     const startTime = Date.now();

--- a/src/client/predictions.ts
+++ b/src/client/predictions.ts
@@ -60,14 +60,14 @@ export class Predictions {
   /**
    * Wait for prediction to complete
    * @param params.id - ID of prediction to wait for
-   * @param params.timeout - Timeout in seconds (default: 60)
+   * @param params.timeout - Timeout in seconds (default: 600)
    * @param params.sleep - Sleep time in seconds (default: 1)
    * @returns Promise containing the prediction response
    * @throws TimeoutError if prediction doesn't complete within timeout
    */
   async wait(
     id: string,
-    timeout: number = 60,
+    timeout: number = 600,
     sleep: number = 1
   ): Promise<PredictionResponse> {
     const startTime = Date.now();

--- a/tests/unit/client/agent.test.ts
+++ b/tests/unit/client/agent.test.ts
@@ -399,7 +399,7 @@ describe("Agent", () => {
       expect(mockOpenAI).toHaveBeenCalledWith({
         apiKey: "test-api-key",
         baseURL: "https://api.example.com/openai",
-        timeout: undefined,
+        timeout: 600000,
         maxRetries: 1,
       });
     });
@@ -426,7 +426,7 @@ describe("Agent", () => {
       expect(mockOpenAI).toHaveBeenCalledWith({
         apiKey: "test-api-key",
         baseURL: "https://agent.vlm.run/v1/openai",
-        timeout: 30000,
+        timeout: 600000,
         maxRetries: 3,
       });
     });


### PR DESCRIPTION
## Summary

Increase timeouts for Orion agent execute and chat completions to ≥600s to prevent premature errors and retries on long-running tasks.

**Changes:**

| Location | Before | After |
|---|---|---|
| `Agent.completions` OpenAI client | `this.client.timeout` (120s default) | `Math.max(timeout ?? 600000, 600000)` |
| `Executions` constructor APIRequestor | 120000ms | 600000ms |
| `Executions.wait()` default | 300s | 600s |
| `Predictions.wait()` default | 60s | 600s |

Updated unit tests in `agent.test.ts` to expect the new 600000ms minimum.

Related PRs: vlm-run/vlmrun-python-sdk (same changes), vlm-run/vlm-lab (server-side timeouts).

Link to Devin session: https://app.devin.ai/sessions/977e2c561b8c4ef8b72d04517946a4dc
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->