### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vlmrun",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vlmrun",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlmrun",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "The official TypeScript library for the VlmRun API",
   "author": "VlmRun <support@vlmrun.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps version from `1.2.1` → `1.3.0` to trigger the `release-on-merge` workflow and publish the unreleased changes from #143 to npm.

New features in this release:
- `model` parameter on `agent.execute()` (default `"vlmrun-orion-1:auto"`)
- `toolsets` parameter on `agent.execute()`
- `agent.getById()` method
- `AgentToolset` type
- `domain` field on `PredictionResponse`
- `steps`, `message`, `duration_seconds` fields on `CreditUsage`

Link to Devin session: https://app.devin.ai/sessions/14a5c68fe8654c2fa33091ce88471a43
Requested by: @dineshreddy91
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->