### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vlmrun",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vlmrun",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlmrun",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The official TypeScript library for the VlmRun API",
   "author": "VlmRun <support@vlmrun.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps package version from `1.3.0` → `1.3.1` to trigger the `release-on-merge` workflow, which publishes to npm only when a version change is detected. This releases the security fixes from #145.

Link to Devin session: https://app.devin.ai/sessions/8d93bc64e8fd4046a47f2fc3080f87f9
Requested by: @DylanSoftware
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->