### PR TITLE
fix: use npm publish instead of yarn publish, bump version to 1.3.2

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -22,4 +22,4 @@ else
 fi
 
 # Publish with the appropriate tag
-yarn publish --access public --tag "$TAG"
+npm publish --access public --tag "$TAG"

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -7,11 +7,16 @@ npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
 # Build the project
 yarn build
 
+# Copy package.json and README into dist so npm publish has package metadata
+cp package.json dist/
+if [ -e README.md ]; then cp README.md dist/; fi
+if [ -e LICENSE ]; then cp LICENSE dist/; fi
+
 # Navigate to the dist directory
 cd dist
 
 # Get the version from package.json
-VERSION="$(node -p "require('../package.json').version")"
+VERSION="$(node -p "require('./package.json').version")"
 
 # Extract the pre-release tag if it exists
 if [[ "$VERSION" =~ -([a-zA-Z]+) ]]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vlmrun",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The official TypeScript library for the VlmRun API",
   "author": "VlmRun <support@vlmrun.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

`bin/publish-npm` was using `yarn publish`, which targets the read-only `registry.yarnpkg.com` mirror instead of `registry.npmjs.org`. This caused every publish to fail with `\"Not found\"`, which is why npm is stuck at 1.2.1 despite `package.json` being at 1.3.1.

Three fixes in `bin/publish-npm`:

```diff
  yarn build
+ cp package.json dist/
+ cp README.md dist/
+ cp LICENSE dist/
  cd dist
- VERSION=\"$(node -p \"require('../package.json').version\")\"
+ VERSION=\"$(node -p \"require('./package.json').version\")\"
  ...
- yarn publish --access public --tag \"$TAG\"
+ npm publish --access public --tag \"$TAG\"
```

1. `yarn publish` → `npm publish` — fixes registry mismatch (yarnpkg.com → npmjs.org)
2. Copy `package.json`, `README.md`, `LICENSE` into `dist/` — `npm publish` requires `package.json` in the current directory (unlike yarn which traverses up)
3. Fix version read from `../package.json` back to `./package.json` since we now copy it into dist/

Also bumps version 1.3.1 → 1.3.2.

Verified with `npm publish --dry-run` — package contents are correct (JS, MJS, DTS, sourcemaps, README, LICENSE) and targets `registry.npmjs.org`.

Link to Devin session: https://app.devin.ai/sessions/9979766dcfa94eb0b0ddbcab749d5bac
Requested by: @DylanSoftware
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->