### PR TITLE
chore: rename release workflow to release-on-version-change

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -1,4 +1,4 @@
-name: Release on Merge
+name: Release on Version Change
 
 on:
   pull_request:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vlmrun",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vlmrun",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.12.2",


### PR DESCRIPTION
## Summary

Rename `release-on-merge.yml` → `release-on-version-change.yml` and `name: Release on Merge` → `name: Release on Version Change` to better reflect the actual behavior — the workflow only publishes when the version in `package.json` changes, not on every merge.

Link to Devin session: https://app.devin.ai/sessions/7c56897f0edd4e468677037930ac4882
Requested by: @shahrear33
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->