### PR TITLE
fix: add exports map and prepublishOnly build guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "vlmrun",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "The official TypeScript library for the VlmRun API",
   "author": "VlmRun <support@vlmrun.com>",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "type": "commonjs",
   "repository": "github:vlm-run/vlmrun-node-sdk",
   "license": "Apache-2.0",
@@ -17,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "prepublishOnly": "npm run build",
     "clean": "rm -rf dist",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Adds an exports field so Vite/Vitest resolvers find the correct CJS/ESM/types entrypoints instead of failing on the missing dist/ condition. Also adds prepublishOnly to ensure dist/ is always built before npm publish, preventing a repeat of the 1.3.2 stale-tarball issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->