### PR TITLE
feat: implement artifacts.list() and add filename param to artifacts.get()

### DIFF
--- a/src/client/artifacts.ts
+++ b/src/client/artifacts.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as os from "os";
 import axios from "axios";
 import { Client } from "./base_requestor";
+import { ArtifactListParams, ArtifactListResponse } from "./types";
 
 const VLMRUN_ARTIFACTS_DIR = path.join(os.homedir(), ".vlmrun", "artifacts");
 
@@ -32,9 +33,10 @@ const CONTENT_TYPE_MAPPING: Record<string, string> = {
 export type ArtifactResponse = Buffer | string;
 
 export interface ArtifactGetParams {
-  objectId: string;
+  objectId?: string;
   sessionId?: string;
   executionId?: string;
+  filename?: string;
   rawResponse?: boolean;
 }
 
@@ -65,7 +67,7 @@ export class Artifacts {
    * @throws Error if neither sessionId nor executionId is provided, or if both are provided
    */
   async get(params: ArtifactGetParams): Promise<ArtifactResponse> {
-    const { objectId, sessionId, executionId, rawResponse = false } = params;
+    const { objectId, sessionId, executionId, filename, rawResponse = false } = params;
 
     // Validate that exactly one of sessionId or executionId is provided
     if (!sessionId && !executionId) {
@@ -76,17 +78,29 @@ export class Artifacts {
         "Only one of `sessionId` or `executionId` is allowed, not both"
       );
     }
+    // Validate that exactly one of objectId or filename is provided
+    if (!objectId && !filename) {
+      throw new Error("Either `objectId` or `filename` is required");
+    }
+    if (objectId && filename) {
+      throw new Error(
+        "Only one of `objectId` or `filename` is allowed, not both"
+      );
+    }
+
+    // Build query parameters
+    const queryParams: Record<string, string> = {};
+    if (sessionId) queryParams.session_id = sessionId;
+    if (executionId) queryParams.execution_id = executionId;
+    if (objectId) queryParams.object_id = objectId;
+    if (filename) queryParams.filename = filename;
 
     // Use the new API endpoint format with data payload
     const response = await axios.get(`${this.client.baseURL}/artifacts`, {
       headers: {
         Authorization: `Bearer ${this.client.apiKey}`,
       },
-      params: {
-        session_id: sessionId,
-        execution_id: executionId,
-        object_id: objectId,
-      },
+      params: queryParams,
       responseType: "arraybuffer",
       timeout: this.client.timeout ?? 120000,
     });
@@ -95,6 +109,11 @@ export class Artifacts {
     const headers = response.headers as Record<string, string>;
 
     if (rawResponse) {
+      return data;
+    }
+
+    // If filename was used instead of objectId, return raw bytes
+    if (!objectId) {
       return data;
     }
 
@@ -182,12 +201,38 @@ export class Artifacts {
   }
 
   /**
-   * List artifacts for a session.
+   * List artifacts for a session or execution.
    *
-   * @param sessionId - Session ID to list artifacts for
-   * @throws NotImplementedError - This method is not yet implemented
+   * @param params - Parameters for listing artifacts
+   * @param params.sessionId - Session ID to list artifacts for (mutually exclusive with executionId)
+   * @param params.executionId - Execution ID to list artifacts for (mutually exclusive with sessionId)
+   * @returns ArtifactListResponse containing the namespace ID and list of artifact items
+   * @throws Error if neither sessionId nor executionId is provided, or if both are provided
    */
-  async list(sessionId: string): Promise<never> {
-    throw new Error("Artifacts.list() is not yet implemented");
+  async list(params: ArtifactListParams): Promise<ArtifactListResponse> {
+    const { sessionId, executionId } = params;
+
+    if (!sessionId && !executionId) {
+      throw new Error("Either `sessionId` or `executionId` is required");
+    }
+    if (sessionId && executionId) {
+      throw new Error(
+        "Only one of `sessionId` or `executionId` is allowed, not both"
+      );
+    }
+
+    const queryParams: Record<string, string> = {};
+    if (sessionId) queryParams.session_id = sessionId;
+    if (executionId) queryParams.execution_id = executionId;
+
+    const response = await axios.get(`${this.client.baseURL}/artifacts/list`, {
+      headers: {
+        Authorization: `Bearer ${this.client.apiKey}`,
+      },
+      params: queryParams,
+      timeout: this.client.timeout ?? 120000,
+    });
+
+    return response.data as ArtifactListResponse;
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -820,6 +820,28 @@ export interface AgentExecuteParamsNew {
 
 // --- Skills types ---
 
+// --- Artifacts types ---
+
+export type ArtifactSource = "store" | "manifest" | "workspace";
+
+export interface ArtifactListItem {
+  object_id: string;
+  filename: string | null;
+  source: ArtifactSource;
+}
+
+export interface ArtifactListResponse {
+  namespace_id: string;
+  items: ArtifactListItem[];
+}
+
+export interface ArtifactListParams {
+  sessionId?: string;
+  executionId?: string;
+}
+
+// --- Skills types ---
+
 export interface SkillInfo {
   id: string;
   name: string;

--- a/tests/unit/client/artifacts.test.ts
+++ b/tests/unit/client/artifacts.test.ts
@@ -41,7 +41,6 @@ describe('Artifacts', () => {
           headers: { Authorization: 'Bearer test-api-key' },
           params: {
             session_id: '550e8400-e29b-41d4-a716-446655440000',
-            execution_id: undefined,
             object_id: 'img_abc123',
           },
           responseType: 'arraybuffer',
@@ -68,7 +67,6 @@ describe('Artifacts', () => {
         'https://api.example.com/artifacts',
         expect.objectContaining({
           params: {
-            session_id: undefined,
             execution_id: 'exec-123-456',
             object_id: 'img_abc123',
           },
@@ -230,13 +228,120 @@ describe('Artifacts', () => {
         })
       ).rejects.toThrow('Expected application/octet-stream');
     });
+
+    it('should get artifact by filename', async () => {
+      const mockData = Buffer.from('mock file content');
+      mockedAxios.get.mockResolvedValue({
+        data: mockData,
+        headers: { 'content-type': 'application/octet-stream' },
+      });
+
+      const result = await artifacts.get({
+        filename: 'report.pdf',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.toString()).toBe('mock file content');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.example.com/artifacts',
+        expect.objectContaining({
+          params: {
+            session_id: '550e8400-e29b-41d4-a716-446655440000',
+            filename: 'report.pdf',
+          },
+        })
+      );
+    });
+
+    it('should throw error when neither objectId nor filename is provided', async () => {
+      await expect(
+        artifacts.get({
+          sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        })
+      ).rejects.toThrow('Either `objectId` or `filename` is required');
+    });
+
+    it('should throw error when both objectId and filename are provided', async () => {
+      await expect(
+        artifacts.get({
+          objectId: 'img_abc123',
+          filename: 'report.pdf',
+          sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        })
+      ).rejects.toThrow('Only one of `objectId` or `filename` is allowed, not both');
+    });
   });
 
   describe('list', () => {
-    it('should throw NotImplementedError', async () => {
+    it('should list artifacts by sessionId', async () => {
+      const mockResponse = {
+        data: {
+          namespace_id: '550e8400-e29b-41d4-a716-446655440000',
+          items: [
+            { object_id: 'img_abc123', filename: 'photo.jpg', source: 'store' },
+            { object_id: 'doc_def456', filename: null, source: 'manifest' },
+          ],
+        },
+      };
+      mockedAxios.get.mockResolvedValue(mockResponse);
+
+      const result = await artifacts.list({
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      expect(result.namespace_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].object_id).toBe('img_abc123');
+      expect(result.items[0].filename).toBe('photo.jpg');
+      expect(result.items[0].source).toBe('store');
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.example.com/artifacts/list',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer test-api-key' },
+          params: { session_id: '550e8400-e29b-41d4-a716-446655440000' },
+        })
+      );
+    });
+
+    it('should list artifacts by executionId', async () => {
+      const mockResponse = {
+        data: {
+          namespace_id: 'exec-123-456',
+          items: [
+            { object_id: 'vid_aaa111', filename: 'clip.mp4', source: 'workspace' },
+          ],
+        },
+      };
+      mockedAxios.get.mockResolvedValue(mockResponse);
+
+      const result = await artifacts.list({
+        executionId: 'exec-123-456',
+      });
+
+      expect(result.namespace_id).toBe('exec-123-456');
+      expect(result.items).toHaveLength(1);
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.example.com/artifacts/list',
+        expect.objectContaining({
+          params: { execution_id: 'exec-123-456' },
+        })
+      );
+    });
+
+    it('should throw error when neither sessionId nor executionId is provided', async () => {
       await expect(
-        artifacts.list('550e8400-e29b-41d4-a716-446655440000')
-      ).rejects.toThrow('Artifacts.list() is not yet implemented');
+        artifacts.list({})
+      ).rejects.toThrow('Either `sessionId` or `executionId` is required');
+    });
+
+    it('should throw error when both sessionId and executionId are provided', async () => {
+      await expect(
+        artifacts.list({
+          sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          executionId: 'exec-123-456',
+        })
+      ).rejects.toThrow('Only one of `sessionId` or `executionId` is allowed, not both');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds SDK support for the new `GET /v1/artifacts/list` endpoint (vlm-lab PR #2001) and extends `artifacts.get()` to accept a `filename` parameter.

**New types** in `src/client/types.ts`:
```typescript
type ArtifactSource = "store" | "manifest" | "workspace";

interface ArtifactListItem {
  object_id: string;
  filename: string | null;
  source: ArtifactSource;
}

interface ArtifactListResponse {
  namespace_id: string;
  items: ArtifactListItem[];
}
```

**`Artifacts.get()`** — new optional `filename` in `ArtifactGetParams` (mutually exclusive with `objectId`):
```typescript
const data = await client.artifacts.get({ filename: "report.pdf", sessionId: "..." });
```

**`Artifacts.list()`** — accepts `ArtifactListParams` with `sessionId` or `executionId`:
```typescript
const response = await client.artifacts.list({ sessionId: "..." });
response.items.forEach(item => console.log(item.object_id, item.filename, item.source));
```

Tests cover all new paths including mutual-exclusivity validation for both `get()` and `list()` (20 tests total).

Link to Devin session: https://app.devin.ai/sessions/13d55013533b4c8d826104e377b2cabb
Requested by: @dineshreddy91