### PR TITLE
feat(types): expose USD cost/tier fields on CreditUsage

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -224,6 +224,11 @@ export interface CreditUsage {
   steps?: number;
   message?: string;
   duration_seconds?: number;
+  service_tier?: string;
+  mode_multiplier?: number;
+  standard_cost_dollars?: number;
+  cost_dollars?: number;
+  savings_dollars?: number;
 }
 
 export interface ModelInfoResponse {

--- a/tests/unit/client/types.test.ts
+++ b/tests/unit/client/types.test.ts
@@ -8,6 +8,8 @@ import {
   VideoUrl,
   AudioUrl,
   DocumentUrl,
+  CreditUsage,
+  PredictionResponse,
 } from "../../../src/client/types";
 
 describe("Types", () => {
@@ -222,6 +224,51 @@ describe("Types", () => {
         url: "https://example.com/document.pdf",
       };
       expect(documentUrl.url).toBe("https://example.com/document.pdf");
+    });
+  });
+
+  describe("CreditUsage dollar fields", () => {
+    it("should expose the dollar/tier fields returned by the API", () => {
+      const usage: CreditUsage = {
+        elements_processed: 1,
+        element_type: "page",
+        credits_used: 50,
+        duration_seconds: 2,
+        service_tier: "flex",
+        mode_multiplier: 0.5,
+        standard_cost_dollars: 1.0,
+        cost_dollars: 0.5,
+        savings_dollars: 0.5,
+      };
+      expect(usage.service_tier).toBe("flex");
+      expect(usage.mode_multiplier).toBe(0.5);
+      expect(usage.standard_cost_dollars).toBe(1.0);
+      expect(usage.cost_dollars).toBe(0.5);
+      expect(usage.savings_dollars).toBe(0.5);
+    });
+
+    it("should allow omitting the dollar/tier fields", () => {
+      const usage: CreditUsage = { credits_used: 100 };
+      expect(usage.cost_dollars).toBeUndefined();
+      expect(usage.service_tier).toBeUndefined();
+    });
+
+    it("should carry the usage dollar fields on a PredictionResponse", () => {
+      const response: PredictionResponse = {
+        id: "pred1",
+        created_at: "2024-01-01T00:00:00Z",
+        completed_at: "2024-01-01T00:00:01Z",
+        response: { invoice_number: "INV-001", total_amount: 100.0 },
+        status: "completed",
+        usage: {
+          credits_used: 50,
+          service_tier: "flex",
+          cost_dollars: 0.5,
+          savings_dollars: 0.5,
+        },
+      };
+      expect(response.usage?.cost_dollars).toBe(0.5);
+      expect(response.usage?.savings_dollars).toBe(0.5);
     });
   });
 });


### PR DESCRIPTION
## Summary

The VLM Run API returns per-request USD cost + service-tier info inside the `usage` object of prediction/execution responses (`CreditUsageResponse` in vlm-lab, populated in `vlm/infra/cloud/billing/usage.py`), but the SDK's `CreditUsage` interface only declared the credit fields — so the dollar fields were dropped and `response.usage.cost_dollars` was untyped/unavailable.

This adds the 5 wire fields to the `CreditUsage` interface:

```diff
 export interface CreditUsage {
   elements_processed?: number;
   element_type?: "image" | "page" | "video" | "audio";
   credits_used?: number;
   steps?: number;
   message?: string;
   duration_seconds?: number;
+  service_tier?: string;
+  mode_multiplier?: number;
+  standard_cost_dollars?: number;
+  cost_dollars?: number;
+  savings_dollars?: number;
 }
```

These mirror exactly the non-excluded fields of the API's `CreditUsageResponse`. The server's `input_tokens` / `output_tokens` / `credit_cost_dollars` are intentionally **not** added — they are `exclude=True` (internal-only, not on the wire).

Applies to both `PredictionResponse.usage` and `AgentExecutionResponse.usage` (both typed as `CreditUsage`).

```ts
const resp = await client.image.generate({ domain: "document.invoice", urls: [...] });
resp.usage?.cost_dollars;      // effective USD charged
resp.usage?.standard_cost_dollars;
resp.usage?.savings_dollars;   // discount on flex tier
resp.usage?.service_tier;      // "standard" | "flex" | "priority"
```

## Test plan
- Added a `CreditUsage dollar fields` describe block to `tests/unit/client/types.test.ts`.
- `yarn jest tests/unit` → 275 passed.
- `tsc --noEmit` (after `yarn build`) → passed.

Companion Python SDK PR: vlm-run/vlmrun-python-sdk (same fields on the `CreditUsage` model).

Link to Devin session: https://app.devin.ai/sessions/af66c3426c7f41188105bcaff4defc1b
Requested by: @jeremyipark
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->