### PR TITLE
feat(agent): expose mode on AgentExecutionConfig

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -722,6 +722,8 @@ export interface AgentCreationResponse {
   status: JobStatus;
 }
 
+export type AgentExecutionMode = "agent" | "program";
+
 export type AgentExecutionConfigParams = {
   prompt?: string;
   responseModel?: ZodType;
@@ -729,6 +731,12 @@ export type AgentExecutionConfigParams = {
   skills?: AgentSkillInput[];
   serviceTier?: "auto" | "default" | "standard" | "flex" | "priority" | null;
   orchestrationMode?: boolean | null;
+  /**
+   * Orion-2 only (ignored for other models). `program`: run cached skill
+   * `pipeline.py` as fixed code when available. `agent`: run the full LLM
+   * agent loop. When omitted, the server default applies.
+   */
+  mode?: AgentExecutionMode | null;
 };
 
 export class AgentExecutionConfig {
@@ -748,6 +756,12 @@ export class AgentExecutionConfig {
    * omitted, the server default applies.
    */
   orchestrationMode?: boolean | null;
+  /**
+   * Orion-2 only (ignored for other models). `program`: run cached skill
+   * `pipeline.py` as fixed code when available. `agent`: run the full LLM
+   * agent loop. When omitted, the server default applies.
+   */
+  mode?: AgentExecutionMode | null;
 
   constructor(params: Partial<AgentExecutionConfig> = {}) {
     Object.assign(this, params);
@@ -764,6 +778,7 @@ export class AgentExecutionConfig {
     if (this.serviceTier !== undefined) json.service_tier = this.serviceTier;
     if (this.orchestrationMode !== undefined)
       json.orchestration_mode = this.orchestrationMode;
+    if (this.mode !== undefined) json.mode = this.mode;
     return json;
   }
 }

--- a/tests/unit/client/agent.test.ts
+++ b/tests/unit/client/agent.test.ts
@@ -646,6 +646,43 @@ describe("Agent", () => {
       expect(call[3].config).not.toHaveProperty("service_tier");
     });
 
+    it.each(["agent", "program"] as const)(
+      "forwards mode=%s to /agent/execute",
+      async (mode) => {
+        jest
+          .spyOn(agent["requestor"], "request")
+          .mockResolvedValue([mockExecuteResponse, 200, {}]);
+
+        await agent.execute({
+          name: "test-agent",
+          config: { prompt: "hi", mode },
+        });
+
+        expect(agent["requestor"].request).toHaveBeenCalledWith(
+          "POST",
+          "agent/execute",
+          undefined,
+          expect.objectContaining({
+            config: expect.objectContaining({ mode }),
+          })
+        );
+      }
+    );
+
+    it("omits mode from /agent/execute payload when not set", async () => {
+      jest
+        .spyOn(agent["requestor"], "request")
+        .mockResolvedValue([mockExecuteResponse, 200, {}]);
+
+      await agent.execute({
+        name: "test-agent",
+        config: { prompt: "hi" },
+      });
+
+      const call = (agent["requestor"].request as jest.Mock).mock.calls[0];
+      expect(call[3].config).not.toHaveProperty("mode");
+    });
+
     it("forwards service_tier through /agent/create", async () => {
       jest
         .spyOn(agent["requestor"], "request")


### PR DESCRIPTION
## Summary
- Add `mode?: "agent" | "program"` to `AgentExecutionConfig` / `AgentExecutionConfigParams`
- Serialize it as `mode` in `toJSON()` (omitted when unset)
- Unit tests cover forward + omit behavior on `/agent/execute`

This matches the Python SDK (`vlmrun>=0.7.1`, [#205](https://github.com/vlm-run/vlmrun-python-sdk/pull/205)) and the `/v1/agent/execute` OpenAPI schema. Without it, cookbook notebook 18’s `mode: "program"` path cannot be expressed from the Node SDK, so grounded `document.extract` pipelines fall back to agent mode and lose `*_metadata.bboxes`.

## Test plan
- [x] `npx jest tests/unit/client/agent.test.ts` (38 passed)
- [ ] Publish npm release after merge


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vlm-run/vlmrun-node-sdk/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->